### PR TITLE
Move statix to the top level module

### DIFF
--- a/lib/metrix/application.ex
+++ b/lib/metrix/application.ex
@@ -2,7 +2,7 @@ defmodule Metrix.Application do
   use Application
 
   def start(_type, _args) do
-    :ok = Metrix.Stats.connect()
+    :ok = Metrix.connect()
 
     children = [
     ]

--- a/lib/metrix/instrumenters/absinthe.ex
+++ b/lib/metrix/instrumenters/absinthe.ex
@@ -31,7 +31,7 @@ defmodule Metrix.Instrumenters.Absinthe do
     metric = metric_name(object, result)
     time   = Stats.microseconds(diff)
     tags   = [field(field), object(object)]
-    Stats.histogram(metric, time, tags: tags)
+    Metrix.histogram(metric, time, tags: tags)
   end
 
   defp metric_name(:query, result) do

--- a/lib/metrix/instrumenters/ecto.ex
+++ b/lib/metrix/instrumenters/ecto.ex
@@ -12,25 +12,25 @@ defmodule Metrix.Instrumenters.Ecto do
   def log_queue_time(entry) do
     metric = metric_name("queue", entry)
     time = value(entry.queue_time)
-    Stats.histogram(metric, time)
+    Metrix.histogram(metric, time)
   end
 
   def log_query_time(entry) do
     metric = metric_name("query", entry)
     time = value(entry.query_time)
-    Stats.histogram(metric, time)
+    Metrix.histogram(metric, time)
   end
 
   def log_decode_time(entry) do
     metric = metric_name("decode", entry)
     time = value(entry.decode_time)
-    Stats.histogram(metric, time)
+    Metrix.histogram(metric, time)
   end
 
   def log_total_time(entry) do
     metric = metric_name("total", entry)
     time = total_time(entry)
-    Stats.histogram(metric, time)
+    Metrix.histogram(metric, time)
   end
 
   defp total_time(entry) do

--- a/lib/metrix/instrumenters/fuse.ex
+++ b/lib/metrix/instrumenters/fuse.ex
@@ -1,8 +1,6 @@
 defmodule Metrix.Instrumenters.Fuse do
   @behaviour :fuse_stats_plugin
 
-  alias Metrix.Stats
-
   @spec init(name::atom()) :: :ok
   def init(_name), do: :ok
 
@@ -10,11 +8,11 @@ defmodule Metrix.Instrumenters.Fuse do
   def increment(name, counter) do
     case counter do
       :ok ->
-        Stats.increment("fuse.ok", 1, tags: tags(name))
+        Metrix.increment("fuse.ok", 1, tags: tags(name))
       :blown ->
-        Stats.increment("fuse.blown", 1, tags: tags(name))
+        Metrix.increment("fuse.blown", 1, tags: tags(name))
       :melt ->
-        Stats.increment("fuse.melted", 1, tags: tags(name))
+        Metrix.increment("fuse.melted", 1, tags: tags(name))
     end
   end
 

--- a/lib/metrix/instrumenters/phoenix.ex
+++ b/lib/metrix/instrumenters/phoenix.ex
@@ -8,7 +8,7 @@ defmodule Metrix.Instrumenters.Phoenix do
     time = Stats.microseconds(time_diff)
     metric = "phoenix.controller.call_duration"
     tags = [controller(conn), action(conn)]
-    Stats.histogram(metric, time, tags: tags)
+    Metrix.histogram(metric, time, tags: tags)
   end
 
   def phoenix_controller_render(:start, compile, data) do
@@ -18,7 +18,7 @@ defmodule Metrix.Instrumenters.Phoenix do
     time   = Stats.microseconds(time_diff)
     metric = "phoenix.controller.render_duration"
     tags   = [controller(conn), view(view), template(template)]
-    Stats.histogram(metric, time, tags: tags)
+    Metrix.histogram(metric, time, tags: tags)
   end
 
   def phoenix_channel_join(:start, compile, data) do
@@ -29,7 +29,7 @@ defmodule Metrix.Instrumenters.Phoenix do
     metric = "phoenix.channel.join"
     tags   = [channel(socket)]
 
-    Stats.histogram(metric, time, tags: tags)
+    Metrix.histogram(metric, time, tags: tags)
   end
 
   def phoenix_channel_receive(:start, compile, data) do
@@ -39,7 +39,7 @@ defmodule Metrix.Instrumenters.Phoenix do
     time   = Stats.microseconds(time_diff)
     metric = "phoenix.channel.receive"
     tags   = [channel(socket), handler(socket), event(event)]
-    Stats.histogram(metric, time, tags: tags)
+    Metrix.histogram(metric, time, tags: tags)
   end
 
   defp controller(conn) do

--- a/lib/metrix/stats.ex
+++ b/lib/metrix/stats.ex
@@ -1,6 +1,4 @@
 defmodule Metrix.Stats do
-  use Statix
-
   def microseconds(time) do
     System.convert_time_unit(time, :native, :microsecond)
   end


### PR DESCRIPTION
Moves the statix module to the top level module to make it easier to use in applications.