### PR TITLE
make Phoenix truly optional

### DIFF
--- a/lib/metrix/instrumenters/phoenix.ex
+++ b/lib/metrix/instrumenters/phoenix.ex
@@ -1,6 +1,5 @@
 defmodule Metrix.Instrumenters.Phoenix do
   alias Metrix.Stats
-  import Phoenix.Controller
 
   def phoenix_controller_call(:start, compile, data) do
     Map.put(data, :compile, compile)
@@ -44,7 +43,7 @@ defmodule Metrix.Instrumenters.Phoenix do
   end
 
   defp controller(conn) do
-    "controller:#{controller_module(conn)}"
+    "controller:#{Phoenix.Controller.controller_module(conn)}"
   end
 
   def view(mod) do
@@ -52,7 +51,7 @@ defmodule Metrix.Instrumenters.Phoenix do
   end
 
   defp action(conn) do
-    "action:#{action_name(conn)}"
+    "action:#{Phoenix.Controller.action_name(conn)}"
   end
 
   defp template(template) do


### PR DESCRIPTION
Prior to this commit when `metrix` was brought into a project as a
dependency that did _not_ have Phoenix as a dependency, `metrix` would
fail to compile because it was unable to `import Phoenix.Controller`.
This commit removes that import and fully qualifies the function calls
to `Phoenix.Controller.action_name` and
`Phoenix.Controller.controller_module` so that dependent projects can
still rely on `metrix`, but don't need to bring `phoenix` in as well.