### PR TITLE
add Band.Instrumenters.Plug

### DIFF
--- a/lib/band/instrumenters/plug.ex
+++ b/lib/band/instrumenters/plug.ex
@@ -1,0 +1,49 @@
+if Code.ensure_loaded?(Plug) do
+  defmodule Band.Instrumenters.Plug do
+    @moduledoc """
+    Instruments Plug connections to report each response to a client,
+    with the request_method, request_path, and response_status as tags
+
+    Usage:
+
+        plug Band.Instrumenters.Plug
+
+    """
+
+    alias Band.Stats
+    alias Plug.Conn
+    @behaviour Plug
+
+    def init(_opts), do: nil
+
+
+    def call(conn, _) do
+
+      start = System.monotonic_time()
+
+      Conn.register_before_send(conn, fn conn ->
+        stop = System.monotonic_time()
+        time_diff = Stats.microseconds(stop - start)
+
+        tags = [request_method(conn), request_path(conn), response_status(conn)]
+
+        Band.histogram("plug.response", time_diff, tags: tags)
+
+        conn
+      end)
+    end
+
+    defp request_method(conn) do
+      "request_method:#{conn.method}"
+    end
+
+    defp request_path(conn) do
+      "request_path:#{conn.request_path}"
+    end
+
+    defp response_status(conn) do
+      "response_status:#{Integer.to_string(conn.status)}"
+    end
+
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,8 @@ defmodule Band.Mixfile do
       {:statix, "~> 1.1"},
       {:absinthe, "~> 1.3", optional: true},
       {:phoenix, "~> 1.3", optional: true},
-      {:fuse, "~> 2.4.0", optional: true},
+      {:fuse, "~> 2.4", optional: true},
+      {:plug, "~> 1.5", optional: true},
       {:ex_doc, "~> 0.18", only: :dev},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -5,6 +5,6 @@
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [], [], "hexpm"},
   "phoenix": {:hex, :phoenix, "1.3.0", "1c01124caa1b4a7af46f2050ff11b267baa3edb441b45dbf243e979cd4c5891b", [], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.3 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [], [], "hexpm"},
-  "plug": {:hex, :plug, "1.4.3", "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed", [], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug": {:hex, :plug, "1.5.0", "224b25b4039bedc1eac149fb52ed456770b9678bbf0349cdd810460e1e09195b", [], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"},
   "statix": {:hex, :statix, "1.1.0", "af9a4586c5cd58f879e0595f06a4790878715de5b8f75f6346693aaa38da2424", [], [], "hexpm"}}


### PR DESCRIPTION
We wanted to have the response status for every request available, and this was the best way I could figure out how to do that.

It uses `increment`, with three tags: `request_method`, `request_path`, and `response_status` -- more could be added of course.

Is this a good approach? One potential issue I see is if you're using the Phoenix instrumenter as well, this is a different metric about the same request that cannot really be tied together. I don't know how to tie them together though. Any ideas?