### PR TITLE
keep the Band GenServer alive after starting it

### DIFF
--- a/lib/band.ex
+++ b/lib/band.ex
@@ -23,6 +23,6 @@ defmodule Band do
 
     Band.connect()
 
-    :ignore
+    {:ok, nil}
   end
 end


### PR DESCRIPTION
It is the process that sends the data to the statsd port, so it needs to stay alive.